### PR TITLE
Make miniconda bin path to be set globally

### DIFF
--- a/Installer_Linux.sh
+++ b/Installer_Linux.sh
@@ -64,9 +64,13 @@ if [ ! -d $install_dir/tools/miniconda3 ]; then
 fi
 
 echo
-echo "Setting PATH if needed..."
-[[ ":$PATH:" != *":/opt/tools/miniconda3/bin:"* ]] && echo 'export PATH=/opt/tools/miniconda3/bin/:$PATH' >> ~/.bashrc
-source ~/.bashrc
+echo "Adjusting PATH globally, if needed..."
+PROFILE_SCRIPT=/etc/profile.d/ocean-navigator.sh
+if [ ! -f  $PROFILE_SCRIPT ]; then
+sudo printf "export PATH=/opt/tools/miniconda3/bin/:$PATH\n" > $PROFILE_SCRIPT # https://unix.stackexchange.com/questions/65803/why-is-printf-better-than-echo
+source /etc/profile # Apply changes
+source ~/.bashrc # Apply user's changes after system
+fi
 
 echo
 echo "Acquiring bathymetry and topography files..."

--- a/Installer_Linux.sh
+++ b/Installer_Linux.sh
@@ -69,6 +69,7 @@ PROFILE_SCRIPT=/etc/profile.d/ocean-navigator.sh
 if [ ! -f  $PROFILE_SCRIPT ]; then
 sudo printf "export PATH=/opt/tools/miniconda3/bin/:$PATH\n" > $PROFILE_SCRIPT # https://unix.stackexchange.com/questions/65803/why-is-printf-better-than-echo
 source /etc/profile # Apply changes
+conda init # Fix some environment issues related to PROJ4
 source ~/.bashrc # Apply user's changes after system
 fi
 


### PR DESCRIPTION
Instead of editing the installing user's `~/.bashrc`, we will add a script to `/etc/profile.d/`. This will fix cases where multiple users wish to use a single installation and the miniconda path isn't set.

I'll be testing this change in a VM.

@dwayne-hart There's 2 schools of thought for global environment variables. There's the method I'm using, and there's also something about `/etc/environment`. Thoughts?