### PR TITLE
Updates 202011052311

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -16,7 +16,7 @@ if [ ! -e bin/.miniconda.installed ] ; then
    if [ $(which wget) ] ; then
       [ ! -d .tmp ] && mkdir .tmp
       printf "\n\t Downloading the latest Miniconda installation package from repo.anaconda.com\n\n"
-      wget --quiet -O .tmp/Miniconda3-latest-Linux-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+      [ ! -e .tmp/Miniconda3-latest-Linux-x86_64.sh ] && wget --quiet -O .tmp/Miniconda3-latest-Linux-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
       bash .tmp/Miniconda3-latest-Linux-x86_64.sh -b -p tools/miniconda/3/amd64
       ./tools/miniconda/3/amd64/bin/conda create --quiet --name navigator --file Ocean-Data-Map-Project/config/conda/navigator-spec-file.txt
       ./tools/miniconda/3/amd64/bin/conda create --quiet --name index-tool --file Ocean-Data-Map-Project/config/conda/index-tool-spec-file.txt

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -11,12 +11,20 @@ if [ ! -e bin/.configuration.updated ] ; then
 fi
 
 if [ ! -e bin/.miniconda.installed ] ; then
-   rm -rf tools/miniconda
-   bash Miniconda3-latest-Linux-x86_64.sh -b -p tools/miniconda/3/amd64
-   ./tools/miniconda/3/amd64/bin/conda create --quiet --name navigator --file Ocean-Data-Map-Project/config/conda/navigator-spec-file.txt
-   ./tools/miniconda/3/amd64/bin/conda create --quiet --name index-tool --file Ocean-Data-Map-Project/config/conda/index-tool-spec-file.txt
-   ./tools/miniconda/3/amd64/bin/conda create --quiet --name nco-tools --file Ocean-Data-Map-Project/config/conda/nco-tools-spec-file.txt
-   ./tools/miniconda/3/amd64/bin/conda create --quiet --name devops --file Ocean-Data-Map-Project/config/conda/devops-spec-file.txt
-   touch bin/.miniconda.installed
-fi
+   [ -d tools/miniconda ] && rm -rf tools/miniconda
 
+   if [ $(which wget) ] ; then
+      [ ! -d .tmp ] && mkdir .tmp
+      printf "\n\t Downloading the latest Miniconda installation package from repo.anaconda.com\n\n"
+      wget --quiet -O .tmp/Miniconda3-latest-Linux-x86_64.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+      bash .tmp/Miniconda3-latest-Linux-x86_64.sh -b -p tools/miniconda/3/amd64
+      ./tools/miniconda/3/amd64/bin/conda create --quiet --name navigator --file Ocean-Data-Map-Project/config/conda/navigator-spec-file.txt
+      ./tools/miniconda/3/amd64/bin/conda create --quiet --name index-tool --file Ocean-Data-Map-Project/config/conda/index-tool-spec-file.txt
+      ./tools/miniconda/3/amd64/bin/conda create --quiet --name nco-tools --file Ocean-Data-Map-Project/config/conda/nco-tools-spec-file.txt
+      ./tools/miniconda/3/amd64/bin/conda create --quiet --name devops --file Ocean-Data-Map-Project/config/conda/devops-spec-file.txt
+      touch bin/.miniconda.installed
+   else
+      printf "\n\t wget is not installed. Exiting!\n\n\n"
+      exit 99
+   fi
+fi


### PR DESCRIPTION
Remove the Miniconda installation package. Implement an automated way to remove an existing tools/miniconda installation, download the latest Linux 64bit version of Miniconda from repo.anaconda.com, and setup the Ocean Navigator toolchain.